### PR TITLE
Always pull latest version of FTXUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ include(FetchContent)
 set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
 FetchContent_Declare(ftxui
   GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
-  GIT_TAG 21d746e8586a59a39ed5c73317812f17264e68d5
 )
 
 FetchContent_GetProperties(ftxui)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ include(FetchContent)
 set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
 FetchContent_Declare(ftxui
   GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
+  GIT_TAG v0.11
 )
 
 FetchContent_GetProperties(ftxui)


### PR DESCRIPTION
This is easier than manually updating CMakeLists.txt for every version.
I had great headaches figuring out why my code worked in the main repository but wouldn't using this template. It was due to cmake downloading an old version of FTXUI. I don't want other people to experience this too.