### PR TITLE
Updated FTXUI version from 4.0.0 to 5.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(FetchContent)
 set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
 FetchContent_Declare(ftxui
   GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
-  GIT_TAG v4.0.0
+  GIT_TAG v5.0.0
 )
 
 FetchContent_GetProperties(ftxui)


### PR DESCRIPTION
Currently, CMake fetches FTXUI's content from the 4.0.0 version of FTXUI.

Because of this, some of the examples provided in the main github repository of FTXUI won't work. (For example: examples/component/window.cpp will not work).

I've updated the GIT_TAG version from "v4.0.0" to "v5.0.0" to ensure that all examples work.