### PR TITLE
Require C++17, bump FTXUI version to v5.0.0, minor tweaks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,30 @@
-cmake_minimum_required (VERSION 3.11)
-
-# --- Fetch FTXUI --------------------------------------------------------------
-include(FetchContent)
-
-set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
-FetchContent_Declare(ftxui
-  GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
-  GIT_TAG v4.0.0
-)
-
-FetchContent_GetProperties(ftxui)
-if(NOT ftxui_POPULATED)
-  FetchContent_Populate(ftxui)
-  add_subdirectory(${ftxui_SOURCE_DIR} ${ftxui_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
-
-# ------------------------------------------------------------------------------
+cmake_minimum_required (VERSION 3.24)
 
 project(ftxui-starter
   LANGUAGES CXX
   VERSION 1.0.0
 )
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# --- Fetch FTXUI --------------------------------------------------------------
+include(FetchContent)
+
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+set(FETCHCONTENT_QUIET OFF)
+
+FetchContent_Declare(ftxui
+  GIT_REPOSITORY https://github.com/arthursonzogni/ftxui.git
+  GIT_TAG        v5.0.0
+  GIT_PROGRESS   TRUE
+  GIT_SHALLOW    TRUE
+  EXCLUDE_FROM_ALL
+)
+FetchContent_MakeAvailable(ftxui)
+# ------------------------------------------------------------------------------
 
 add_executable(ftxui-starter src/main.cpp)
 target_include_directories(ftxui-starter PRIVATE src)
@@ -28,15 +32,15 @@ target_include_directories(ftxui-starter PRIVATE src)
 target_link_libraries(ftxui-starter
   PRIVATE ftxui::screen
   PRIVATE ftxui::dom
-  PRIVATE ftxui::component # Not needed for this example.
+  PRIVATE ftxui::component  # Not needed for this example.
 )
 
-if (EMSCRIPTEN) 
-  string(APPEND CMAKE_CXX_FLAGS " -s USE_PTHREADS") 
-  string(APPEND CMAKE_EXE_LINKER_FLAGS " -s ASYNCIFY") 
-  string(APPEND CMAKE_EXE_LINKER_FLAGS " -s PROXY_TO_PTHREAD") 
+if (EMSCRIPTEN)
+  string(APPEND CMAKE_CXX_FLAGS " -s USE_PTHREADS")
+  string(APPEND CMAKE_EXE_LINKER_FLAGS " -s ASYNCIFY")
+  string(APPEND CMAKE_EXE_LINKER_FLAGS " -s PROXY_TO_PTHREAD")
 
   foreach(file "index.html" "run_webassembly.py")
     configure_file("src/${file}" ${file})
   endforeach(file)
-endif() 
+endif()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ int main() {
   auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));
   Render(screen, document);
 
-  std::cout << screen.ToString() << "\0\n";
+  std::cout << screen.ToString() << '\0' << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 
-#include "ftxui/dom/elements.hpp"
-#include "ftxui/screen/screen.hpp"
-#include "ftxui/screen/string.hpp"
+#include <ftxui/dom/elements.hpp>
+#include <ftxui/screen/screen.hpp>
+#include <ftxui/screen/string.hpp>
 
 int main(void) {
   using namespace ftxui;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include <ftxui/screen/screen.hpp>
 #include <ftxui/screen/string.hpp>
 
-int main(void) {
+int main() {
   using namespace ftxui;
 
   auto summary = [&] {
@@ -33,7 +33,7 @@ int main(void) {
   auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));
   Render(screen, document);
 
-  std::cout << screen.ToString() << '\0' << std::endl;
+  std::cout << screen.ToString() << "\0\n";
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
I have made a couple of tweaks, mostly inspired by your [json-tui](https://github.com/ArthurSonzogni/json-tui) project:

- Increased the minimum required CMake version to 3.24.
- Added global requirement for C++17 without compiler extensions.
- Enabled verbose mode for `FetchContent` with `GIT_PROGRESS`.
- Limited the download of FTXUI to only the most recent commit (`GIT_SHALLOW`) and excluded it from the build unless explicitly requested (`EXCLUDE_FROM_ALL`).
- Replaced `GetProperties` and `Populate` with `MakeAvailable`.
- Replaced quotes with angle brackets in `main.cpp`.
- Removed `void` and `std::endl` from `main.cpp`.

After adding an install target, the program correctly runs from `/usr/local/bin` on macOS.