### PR TITLE
Lower required CMake version to 3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.24)
+cmake_minimum_required (VERSION 3.22)
 
 project(ftxui-starter
   LANGUAGES CXX


### PR DESCRIPTION
This change lowers the minimum required version of CMake from 3.24 to 3.22, ensuring compatibility with existing builds and allowing users to work with earlier versions.

It may be possible to reduce the required version even further, but I have not tested that.